### PR TITLE
:bug: Fix u-pie-chart infinite update loop

### DIFF
--- a/src/components/u-pie-chart.vue/index.html
+++ b/src/components/u-pie-chart.vue/index.html
@@ -20,7 +20,7 @@
                             <u-chart-tooltip type="piechart" :row="item" :vnode="$scopedSlots.tooltip"></u-chart-tooltip>
                         </m-popper>
                     </circle>
-                    <path v-else :class="$style.item" :d="getD(item)"
+                    <path v-else :class="$style.item" :d="item.d"
                         :color="item.color" :style="{ fill: item.color }"
                         :selected="item === selectedItem" @mouseover="onMouseOver(item)">
                         <m-popper :class="$style.tooltip" trigger="hover" placement="right-start" offset="0 10" follow-cursor>


### PR DESCRIPTION
问题表现:

+ 线上无法打开相关组件文档，页面假死，线下会报错 `infinite update loop`

原因：

+ `html` 中调用 `getD(item)` 会动态改变 `item` 的属性值

解决方案:

+ 在 `handleData` 时，立刻调用 `getD(item)` 对 `item` 进行处理即可