### PR TITLE
:bug: Fix u-calendar not reset current date

### DIFF
--- a/src/components/u-calendar.vue/index.html
+++ b/src/components/u-calendar.vue/index.html
@@ -21,7 +21,7 @@
     </div>
     <div :class="$style.content">
         <div :class="$style.week"><span :class="$style.dayitem" role="week">{{ $t('Sunday') }}</span><span :class="$style.dayitem">{{ $t('Monday') }}</span><span :class="$style.dayitem">{{ $t('Tuesday') }}</span><span :class="$style.dayitem">{{ $t('Wednesday') }}</span><span :class="$style.dayitem">{{ $t('Thursday') }}</span><span :class="$style.dayitem">{{ $t('Friday') }}</span><span :class="$style.dayitem" role="week">{{ $t('Saturday') }}</span></div>
-        <div :class="$style.day"><span v-for="day in days_" :class="$style.item" :sel="showDate.toDateString() === day.toDateString() ? 'sel' : ''" :disabled="!!isOutOfRange(day)" :role="showDate.getMonth() !== day.getMonth() ? 'muted': ''" @click.stop="select(day)">{{day | format('DD')}}</span></div>
+        <div :class="$style.day"><span v-for="day in days_" :class="$style.item" :sel="formatDate.toDateString() === day.toDateString() ? 'sel' : ''" :disabled="!!isOutOfRange(day)" :role="showDate.getMonth() !== day.getMonth() ? 'muted': ''" @click.stop="select(day)">{{day | format('dd')}}</span></div>
         <slot></slot>
     </div>
 </div>

--- a/src/components/u-calendar.vue/index.js
+++ b/src/components/u-calendar.vue/index.js
@@ -82,8 +82,7 @@ export const UCalendar = {
     },
     watch: {
         date(newValue) {
-            this.showDate = this.transformDate(newValue);
-            this.updateFlag = true;
+            this.updateShowDate(newValue);
         },
         yearvisible(yearvisible) {
             if (yearvisible) {
@@ -140,6 +139,13 @@ export const UCalendar = {
         this.update();
     },
     methods: {
+        updateShowDate(newValue) {
+            const newDate = this.transformDate(newValue);
+            if ((newDate - 0) !== (this.showDate - 0)) {
+                this.showDate = newDate;
+                this.updateFlag = true;
+            }
+        },
         yearSelect(value) {
             this.showYear = value;
             this.yearvisible = false;

--- a/src/components/u-calendar.vue/index.js
+++ b/src/components/u-calendar.vue/index.js
@@ -54,6 +54,9 @@ export const UCalendar = {
                 this.showDate = new Date(date);
             },
         },
+        formatDate() {
+            return new Date(this.transformDate(this.date));
+        },
         showMonth: {
             get() {
                 const date = this.transformDate(this.showDate);

--- a/src/components/u-date-picker.vue/index.html
+++ b/src/components/u-date-picker.vue/index.html
@@ -3,9 +3,9 @@
     <span v-if="showDate && reset" :class="[$style.wrap, $style.close]" @click.stop="resetValue">
         <i :class="[$style.icon, $style.closeIcon]"></i>
     </span>
-    <m-popper :class="$style.popper" ref="popper" appendTo="reference" :disabled="disabled || readonly" :placement="placement" @toggle="onToggle($event)">
+    <m-popper :class="$style.popper" ref="popper" appendTo="reference" :disabled="disabled || readonly" :placement="placement" @toggle="onToggle($event)" @close="closeCalendar">
         <div :class="$style.body" @click.stop>
-            <u-calendar :minDate="minDate" :year-diff="yearDiff" :year-add="yearAdd" :maxDate="maxDate" :date="showDate" @select="select($event.date)"/>
+            <u-calendar ref="calendar" :minDate="minDate" :year-diff="yearDiff" :year-add="yearAdd" :maxDate="maxDate" :date="showDate" @select="select($event.date)"/>
         </div>
     </m-popper>
 </div>

--- a/src/components/u-date-picker.vue/index.html
+++ b/src/components/u-date-picker.vue/index.html
@@ -1,5 +1,5 @@
 <div :class="$style.header">
-    <input :class="$style.input" :placeholder="placeholder" :value="showDate" ref="input" :autofocus="autofocus" :readonly="readonly" :disabled="disabled" :style="{width: width+'px'}"  @change="onInput($event)">
+    <input :class="$style.input" :placeholder="placeholder" @click.stop="$refs.popper.toggle(true)" :value="showDate" ref="input" :autofocus="autofocus" :readonly="readonly" :disabled="disabled" :style="{width: width+'px'}"  @change="onInput($event)">
     <span v-if="showDate && reset" :class="[$style.wrap, $style.close]" @click.stop="resetValue">
         <i :class="[$style.icon, $style.closeIcon]"></i>
     </span>

--- a/src/components/u-date-picker.vue/index.js
+++ b/src/components/u-date-picker.vue/index.js
@@ -191,6 +191,10 @@ export const UDatePicker = {
         },
         format,
         transformDate,
+        closeCalendar() {
+            if (this.showDate)
+                this.$refs.calendar.updateShowDate(this.showDate);
+        },
         returnTime(date) {
             if (!date)
                 return;


### PR DESCRIPTION
问题复现步骤:

+ 在打开日历选择框的情况下，更改年份月份，不选择日期，直接关闭弹框。
+ 再次打开日历选择框，此时显示的年份月份均是上次选择的，而不是输入框内的时间。


+ 不停的点击输入框，日历选择框不停的显隐


+ 在更改年月的情况下，选中的日期显示错误