### PR TITLE
:bug: Fix m-singlex-item active when router like: /a/b**

### DIFF
--- a/src/components/m-singlex.vue/docs/cases.md
+++ b/src/components/m-singlex.vue/docs/cases.md
@@ -65,6 +65,7 @@ export default {
     <m-singlex-item to="/components/m-singlex">MSinglex</m-singlex-item>
     <m-singlex-item exact to="/components/m-singlex">MSinglex Exact</m-singlex-item>
     <m-singlex-item to="/components/m-singlex/cases">Cases</m-singlex-item>
+    <m-singlex-item to="/components" activeRule="/components/m-singlex">ActiveRule</m-singlex-item>
     <m-singlex-item to="/components/m-multiplex">MMultiplex</m-singlex-item>
     <m-singlex-item to="/components/m-multiplex" disabled>MMultiplex Disabled</m-singlex-item>
     <m-singlex-item href="/">Href</m-singlex-item>

--- a/src/components/m-singlex.vue/item.vue/index.js
+++ b/src/components/m-singlex.vue/item.vue/index.js
@@ -16,6 +16,7 @@ export const MSinglexItem = {
         item: Object,
         exact: { type: Boolean, default: false },
         exactHash: { type: Boolean, default: false },
+        activeRule: [String, Function],
     },
     data() {
         return {
@@ -38,10 +39,17 @@ export const MSinglexItem = {
             const currentPath = current.path.replace(trailingSlashRE, '/');
             const targetPath = (target.redirectedFrom ? this.$router.resolve(target.redirectedFrom).location.path : target.path).replace(trailingSlashRE, '/');
             // @TODO: 是否要检查 query 的包含关系
-
-            const exact = this.exact ? currentPath === targetPath : currentPath.startsWith(targetPath);
-            const exactHash = this.exactHash ? current.hash === target.hash : current.hash.startsWith(target.hash);
-            return exact && exactHash;
+            let active = false;
+            if (!this.activeRule) {
+                const exact = this.exact ? currentPath === targetPath : currentPath.startsWith(targetPath);
+                const exactHash = this.exactHash ? current.hash === target.hash : current.hash.startsWith(target.hash);
+                active = exact && exactHash;
+            } else if (typeof this.activeRule === 'string') {
+                active = (currentPath.indexOf(this.activeRule) === 0);
+            } else {
+                active = this.activeRule(targetPath);
+            }
+            return active;
         },
     },
     methods: {

--- a/src/components/u-navbar.vue/api.yaml
+++ b/src/components/u-navbar.vue/api.yaml
@@ -154,6 +154,9 @@
       type: boolean
       default: false
       description: 需要 vue-router，与`<router-link>`的`exact`属性相同。是否与路由完全一致时才高亮显示。
+    - name: activeRule
+      type: string, Function
+      description: 需要 vue-router。如果值为 string，当前路由前缀匹配该值才高亮显示。如果值为 Function 时，会将 `to.path` 传递给该函数，由该函数的返回值决定是否高亮显示。
   slots:
     - name: default
       description: 插入文本或 HTML。

--- a/src/components/u-navbar.vue/docs/examples.md
+++ b/src/components/u-navbar.vue/docs/examples.md
@@ -23,7 +23,8 @@
 
 ``` html
 <u-navbar style="background: #4289db;">
-    <u-navbar-item to="u-navbar">组件</u-navbar-item>
+    <u-navbar-item to="/components/u-navbar">UNavbar</u-navbar-item>
+    <u-navbar-item to="/components/u-sidebar" activeRule="/components">USidebar</u-navbar-item>
     <u-navbar-item>备案管理</u-navbar-item>
     <u-navbar-item disabled>帮助</u-navbar-item>
     <u-navbar-item href="https://github.com/vusion/cloud-ui">GitHub</u-navbar-item>

--- a/src/components/u-sidebar.vue/api.yaml
+++ b/src/components/u-sidebar.vue/api.yaml
@@ -153,6 +153,9 @@
       type: boolean
       default: false
       description: 需要 vue-router，与`<router-link>`的`exact`属性相同。是否与路由完全一致时才高亮显示。
+    - name: activeRule
+      type: string, Function
+      description: 需要 vue-router。如果值为 string，当前路由前缀匹配该值才高亮显示。如果值为 Function 时，会将 `to.path` 传递给该函数，由该函数的返回值决定是否高亮显示。
   slots:
     - name: default
       description: 插入文本或 HTML。

--- a/src/components/u-sidebar.vue/docs/examples.md
+++ b/src/components/u-sidebar.vue/docs/examples.md
@@ -6,7 +6,7 @@
 <u-sidebar style="width: 200px;">
     <u-sidebar-item>指南</u-sidebar-item>
     <u-sidebar-item>概念</u-sidebar-item>
-    <u-sidebar-item to="/cloud-ui">组件</u-sidebar-item>
+    <u-sidebar-item to="/cloud-ui" activeRule="/components">组件</u-sidebar-item>
 </u-sidebar>
 ```
 


### PR DESCRIPTION
当定义的路由为 `/a/b**` 的时候，`navbar-item` 在其子路由的时候不生效
添加一个属性 `activeRule`，当存在这个属性的时候，直接由其控制 `active` 的状态。
