### PR TITLE
:sparkles: support checkStrictly for u-tree-view

### DIFF
--- a/src/components/u-tree-view.vue/api.yaml
+++ b/src/components/u-tree-view.vue/api.yaml
@@ -49,6 +49,11 @@
       type: boolean
       default: false
       description: 是否禁用
+    - name: check-strictly
+      title: 完全受控
+      type: boolean
+      default: false
+      description: checkable 开启情况下，是否完全受控（父子节点状态不关联）
   slots:
     - name: default
       description: 插入`<u-tree-view-node>`子组件

--- a/src/components/u-tree-view.vue/docs/examples.md
+++ b/src/components/u-tree-view.vue/docs/examples.md
@@ -503,6 +503,36 @@ export default {
 </script>
 ```
 
+通过 `check-strictly` 属性开启节点状态完全受控，父子不关联。
+
+``` vue { width: 30% }
+<template>
+<u-tree-view ref="treeView" check-strictly checkable :values.sync="values" :data="data"></u-tree-view>
+</template>
+<script>
+export default {
+    data() {
+        return {
+            values: ['1', '1.2', '1.2.1', '1.2.2'],
+            data: [
+                { text: '节点 1', value: '1', expanded: true, checked: false, children: [
+                    { text: '节点 1.1', value: '1.1', expanded: false, checked: false },
+                    { text: '节点 1.2', value: '1.2', expanded: true, checked: false, children: [
+                        { text: '节点 1.2.1', value: '1.2.1', expanded: false, checked: false },
+                        { text: '节点 1.2.2', value: '1.2.2', expanded: false, checked: false },
+                    ] },
+                    { text: '节点 1.3', value: '1.3', expanded: false, checked: false },
+                    { text: '节点 1.4', value: '1.4', expanded: false, checked: false },
+                ] },
+                { text: '节点 2', value: '2', expanded: false, checked: false },
+                { text: '节点 3', value: '3', expanded: false, checked: false },
+            ],
+        };
+    },
+};
+</script>
+```
+
 ### 其他方法
 
 #### 统一操作

--- a/src/components/u-tree-view.vue/index.vue
+++ b/src/components/u-tree-view.vue/index.vue
@@ -43,6 +43,7 @@ export default {
         initialLoad: { type: Boolean, default: true },
         readonly: { type: Boolean, default: false },
         disabled: { type: Boolean, default: false },
+        checkStrictly: { type: Boolean, default: false },
     },
     data() {
         return {
@@ -163,8 +164,13 @@ export default {
             } else {
                 const values = [];
                 this.walk((nodeVM) => {
-                    if (nodeVM.currentChecked && !nodeVM.nodeVMs.length)
-                        values.push(nodeVM.value);
+                    if (nodeVM.currentChecked) {
+                        if (this.checkStrictly) {
+                            values.push(nodeVM.value);
+                        } else if (!nodeVM.nodeVMs.length) {
+                            values.push(nodeVM.value);
+                        }
+                    }
                 });
                 this.currentValues = values;
             }

--- a/src/components/u-tree-view.vue/node.vue
+++ b/src/components/u-tree-view.vue/node.vue
@@ -259,6 +259,20 @@ export default {
             } else
                 final();
         },
+        checkStrictly(checked) {
+            this.currentChecked = checked;
+            this.$emit('update:checked', checked, this);
+            if (
+                checked
+                && !this.rootVM.currentValues.includes(this.value)
+            )
+                this.rootVM.currentValues.push(this.value);
+            else if (!checked && this.rootVM.currentValues.includes(this.value))
+                this.rootVM.currentValues.splice(
+                    this.rootVM.currentValues.indexOf(this.value),
+                    1,
+                );
+        },
         checkRecursively(checked, direction = 'up+down') {
             this.currentChecked = checked;
             this.$emit('update:checked', checked, this);
@@ -305,7 +319,11 @@ export default {
         check(checked) {
             const oldChecked = this.currentChecked;
 
-            this.checkRecursively(checked);
+            if (this.rootVM.checkStrictly) {
+                this.checkStrictly(checked);
+            } else {
+                this.checkRecursively(checked);
+            }
 
             this.$emit(
                 'check',


### PR DESCRIPTION
## UTreeView 树型视图增加完全受控状态

- 开启 `checkable` 多选模式下，通过增加 `check-strictly` 属性开启完全受控（父子状态不关联）
- 增加 `API` 文档和相关案例