### PR TITLE
fix: 修复TableView组件在受控状态下check事件触发多次的问题

### DIFF
--- a/src/components/u-tree-view-new.vue/index.vue
+++ b/src/components/u-tree-view-new.vue/index.vue
@@ -236,7 +236,7 @@ export default {
                 this.currentValues = values;
                 this.walk((nodeVM) => {
                     if (values.includes(nodeVM.value))
-                        nodeVM.check(true);
+                        nodeVM.check(true, true);
                 });
             } else {
                 const values = [];

--- a/src/components/u-tree-view-new.vue/node.vue
+++ b/src/components/u-tree-view-new.vue/node.vue
@@ -416,8 +416,11 @@ export default {
                     parentVM.checkRecursively(null, 'up');
             }
         },
-        check(checked) {
+        check(checked, fromInside = false) {
             const oldChecked = this.currentChecked;
+            if (checked === oldChecked) {
+                return;
+            }
 
             if (this.rootVM.checkControlled) {
                 this.checkControlled(checked);
@@ -435,8 +438,9 @@ export default {
                 },
                 this,
             );
-
-            this.rootVM.onCheck(this, checked, oldChecked);
+            if (!fromInside) {
+                this.rootVM.onCheck(this, checked, oldChecked);
+            }
         },
         renderSelectedVm() {
             if (!this.$parent || !this.$parent.$options.name === 'u-tree-view-new')


### PR DESCRIPTION
fix: 修复TableView组件在受控状态下check事件触发多次的问题,事件链路为：

node.check -> update currentValue(value) -> value(watcher) -> tigger node.check