### PR TITLE
Fix/table view expander with tree conflict 230807 hanshijie

### DIFF
--- a/src/components/u-table-view.vue/docs/examples.md
+++ b/src/components/u-table-view.vue/docs/examples.md
@@ -1971,7 +1971,7 @@ export default {
         getList() {
             return [
                 { name: '张三', phone: '18612917895', email: 'zhangsan@163.com', address: '浙江省杭州市滨江区网商路599号网易大厦', createdTime: 1464421931000, loginTime: 1527515531000},
-                { name: '张三dd', phone: '18612917895', email: 'zhangsan@163.com', address: '浙江省杭州市滨江区网商路599号网易大厦', createdTime: 1464421931000, loginTime: 1527515531000, expanded:true, children:[
+                { name: '张三dd', phone: '18612917895', email: 'zhangsan@163.com', address: '浙江省杭州市滨江区网商路599号网易大厦', createdTime: 1464421931000, loginTime: 1527515531000, treeExpanded:true, children:[
                     { name: '张三11', phone: '18612917895', email: 'zhangsan@163.com', address: '浙江省杭州市滨江区网商路599号网易大厦', createdTime: 1464421931000, loginTime: 1527515531000},
                     { name: '张三12', phone: '18612917895', email: 'zhangsan@163.com', address: '浙江省杭州市滨江区网商路599号网易大厦', createdTime: 1464421931000, loginTime: 1527515531000,children:[
                     { name: '张三121', phone: '18612917895', email: 'zhangsan@163.com', address: '浙江省杭州市滨江区网商路599号网易大厦', createdTime: 1464421931000, loginTime: 1527515531000},
@@ -2081,7 +2081,7 @@ export default {
         getList() {
             return [
                 { name: '张三', phone: '18612917895', email: 'zhangsan@163.com', address: '浙江省杭州市滨江区网商路599号网易大厦', createdTime: 1464421931000, loginTime: 1527515531000},
-                { name: '张三dd', phone: '18612917895', email: 'zhangsan@163.com', address: '浙江省杭州市滨江区网商路599号网易大厦', createdTime: 1464421931000, loginTime: 1527515531000, expanded:true, children:[
+                { name: '张三dd', phone: '18612917895', email: 'zhangsan@163.com', address: '浙江省杭州市滨江区网商路599号网易大厦', createdTime: 1464421931000, loginTime: 1527515531000, treeExpanded:true, children:[
                     { name: '张三11', phone: '18612917895', email: 'zhangsan@163.com', address: '浙江省杭州市滨江区网商路599号网易大厦', createdTime: 1464421931000, loginTime: 1527515531000},
                     { name: '张三12', phone: '18612917895', email: 'zhangsan@163.com', address: '浙江省杭州市滨江区网商路599号网易大厦', createdTime: 1464421931000, loginTime: 1527515531000,children:[
                     { name: '张三121', phone: '18612917895', email: 'zhangsan@163.com', address: '浙江省杭州市滨江区网商路599号网易大厦', createdTime: 1464421931000, loginTime: 1527515531000},

--- a/src/components/u-table-view.vue/index.vue
+++ b/src/components/u-table-view.vue/index.vue
@@ -1731,7 +1731,7 @@ export default {
                     item.treeExpanded = item.treeExpanded || false;
                 }
                 if (parent) {
-                    this.$set(item, 'display', parent.expanded ? '' : 'none');
+                    this.$set(item, 'display', parent.treeExpanded ? '' : 'none');
                 }
                 if (!item.hasOwnProperty('loading')) {
                     this.$set(item, 'loading', false);

--- a/src/components/u-table-view.vue/index.vue
+++ b/src/components/u-table-view.vue/index.vue
@@ -137,7 +137,7 @@
                                             <span :class="$style.expander" v-if="columnVM.type === 'expander'" :expanded="item.expanded" @click.stop="toggleExpanded(item)"></span>
                                             <template v-if="treeDisplay && item.tableTreeItemLevel !== undefined && columnIndex === treeColumnIndex">
                                                 <span :class="$style.indent" :style="{ paddingLeft: number2Pixel(20 * item.tableTreeItemLevel) }"></span>
-                                                <span :class="$style.tree_expander" v-if="$at(item, hasChildrenField)" :expanded="item.expanded" @click.stop="toggleTreeExpanded(item)" :loading="item.loading"></span>
+                                                <span :class="$style.tree_expander" v-if="$at(item, hasChildrenField)" :expanded="item.treeExpanded" @click.stop="toggleTreeExpanded(item)" :loading="item.loading"></span>
                                                 <span :class="$style.tree_placeholder" v-else></span>
                                             </template>
                                             <!-- Normal text -->
@@ -186,7 +186,7 @@
                                             <span :class="$style.expander" v-if="columnVM.type === 'expander'" :expanded="item.expanded" :disabled="item.disabled" @click.stop="toggleExpanded(item)"></span>
                                             <template v-if="treeDisplay && item.tableTreeItemLevel !== undefined && columnIndex === treeColumnIndex">
                                                 <span :class="$style.indent" :style="{ paddingLeft: number2Pixel(20 * item.tableTreeItemLevel) }"></span>
-                                                <span :class="$style.tree_expander" v-if="$at(item, hasChildrenField)" :expanded="item.expanded" @click.stop="toggleTreeExpanded(item)" :loading="item.loading"></span>
+                                                <span :class="$style.tree_expander" v-if="$at(item, hasChildrenField)" :expanded="item.treeExpanded" @click.stop="toggleTreeExpanded(item)" :loading="item.loading"></span>
                                                 <span :class="$style.tree_placeholder" v-else></span>
                                             </template>
                                             <!-- type === 'dragHandler' -->
@@ -1709,6 +1709,7 @@ export default {
                 return;
             this.$set(item, 'expanded', expanded);
             this.$emit('toggle-expanded', { item, expanded }, this);
+            this.$forceUpdate();
             if (expanded && this.accordion) {
                 this.currentData.forEach((otherItem) => {
                     if (otherItem !== item && otherItem.expanded)
@@ -1727,6 +1728,7 @@ export default {
                 if (this.$at(item, this.childrenField) && this.$at(item, this.childrenField).length) {
                     this.$setAt(item, this.hasChildrenField, true);
                     item.expanded = item.expanded || false;
+                    item.treeExpanded = item.treeExpanded || false;
                 }
                 if (parent) {
                     this.$set(item, 'display', parent.expanded ? '' : 'none');
@@ -1745,10 +1747,10 @@ export default {
             if (item.loading)
                 return;
             if (expanded === undefined)
-                expanded = !item.expanded;
+                expanded = !item.treeExpanded;
             if (this.$emitPrevent('before-tree-toggle-expanded', { item, oldExpanded: !expanded, expanded }, this))
                 return;
-            this.$set(item, 'expanded', expanded);
+            this.$set(item, 'treeExpanded', expanded);
             this.$emit('tree-toggle-expanded', { item, expanded }, this);
             if (!this.$at(item, this.childrenField) && (typeof this.dataSource === 'function')) {
                 this.$set(item, 'loading', true);
@@ -1804,7 +1806,7 @@ export default {
                 this.currentData.forEach((itemData) => {
                     if (itemData.parentPointer !== undefined && itemData.parentPointer === parent) {
                         if (expanded) {
-                            if (parent.expanded) {
+                            if (parent.treeExpanded) {
                                 this.$set(itemData, 'display', '');
                             } else {
                                 this.$set(itemData, 'display', 'none');


### PR DESCRIPTION
fix: 树形列与展开列并存时数据列表会同时触发


bug原因为：树形列和展开列混用了同一个expanded属性，现在树节点的展开使用treeExpanded（展开列仍旧使用expanded）