### PR TITLE
fix:修复USelect内部的UInput在暗黑主题下字体颜色异常

### DIFF
--- a/src/components/u-select.vue/index.css
+++ b/src/components/u-select.vue/index.css
@@ -189,6 +189,10 @@
     right: 8px;
 }
 
+.root[color="inverse"] .input {
+    color: var(--select-color-inverse);
+}
+
 .root[clearable],
 .root[suffix],
 .root .input:not([multiple-tags])[filterable],


### PR DESCRIPTION
fix:修复USelect内部的UInput在暗黑主题下字体颜色异常