### PR TITLE
fix: 处理树形表格在计算当前行是否显示时的计算错误

### DIFF
--- a/src/components/u-table-view.vue/index.vue
+++ b/src/components/u-table-view.vue/index.vue
@@ -1720,7 +1720,7 @@ export default {
         /**
          * 转换成平铺型数据
          */
-        processTreeData(data, level = 0, parent) {
+        processTreeData(data, level = 0, parent, ancestors = []) {
             let newData = [];
             for (const item of data) {
                 item.tableTreeItemLevel = level;
@@ -1731,17 +1731,27 @@ export default {
                     item.treeExpanded = item.treeExpanded || false;
                 }
                 if (parent) {
-                    this.$set(item, 'display', parent.treeExpanded ? '' : 'none');
+                    this.$set(item, 'display', needHidden(ancestors) ? 'none' : '');
                 }
                 if (!item.hasOwnProperty('loading')) {
                     this.$set(item, 'loading', false);
                 }
                 newData.push(item);
                 if (this.$at(item, this.childrenField) && this.$at(item, this.childrenField).length) {
-                    newData = newData.concat(this.processTreeData(this.$at(item, this.childrenField), level + 1, item));
+                    newData = newData.concat(this.processTreeData(this.$at(item, this.childrenField), level + 1, item, ancestors.concat(item)));
                 }
             }
             return newData;
+
+            // 只要任意祖先节点的treeExpanded为false,当前节点都不显示。
+            function needHidden(ancestors) {
+                for (const item of ancestors) {
+                    if (!item.treeExpanded) {
+                        return true;
+                    }
+                }
+                return false;
+            }
         },
         toggleTreeExpanded(item, expanded) {
             if (item.loading)


### PR DESCRIPTION
处理树形表格在计算当前行是否显示时的计算错误:

之前：当前行是否显示仅有直接父节点来控制

现在：当前行是否显示会综合考虑所有祖先节点，这更符合预期