### PR TITLE
fix: 调整UTreeSelectNew的ifExpanded属性的默认值与UTreeViewNew相同

### DIFF
--- a/src/components/u-tree-select-new.vue/index.vue
+++ b/src/components/u-tree-select-new.vue/index.vue
@@ -181,7 +181,7 @@ export default {
             default: 30,
         },
         filterFields: { type: Array, default: () => ['text'] },
-        ifExpanded: { type: Boolean, default: true },
+        ifExpanded: { type: Boolean, default: false },
     },
     data() {
         return {


### PR DESCRIPTION
fix: 调整UTreeSelectNew的ifExpanded属性的默认值与UTreeViewNew相同