### PR TITLE
fix: UTableView隐藏[显示边框]属性

### DIFF
--- a/src/components/u-table-view.vue/api.yaml
+++ b/src/components/u-table-view.vue/api.yaml
@@ -515,6 +515,7 @@
       tooltipLink: ""
     - name: border
       title: 显示边框
+      advanced: true
       type: boolean
       default: false
       description: ""


### PR DESCRIPTION
fix: UTableView隐藏[显示边框]属性

当前属性并没有相对应的样式，而且与编辑器样式面板的边框设置功能功能重复