### PR TITLE
fix: 修复UTableView的全选按钮的disable样式

### DIFF
--- a/src/components/u-table-view.vue/index.vue
+++ b/src/components/u-table-view.vue/index.vue
@@ -41,7 +41,7 @@
                             :rowspan="hasGroupedColumn && trIndex === 0 && !columnVM.isGroup ? 2 : undefined">
                             <!-- type === 'checkbox' -->
                             <span v-if="columnVM.type === 'checkbox'">
-                                <u-checkbox :value="allChecked" @check="checkAll($event.value)"></u-checkbox>
+                                <u-checkbox :value="allChecked" @check="checkAll($event.value)" :disabled="disabled"></u-checkbox>
                             </span>
                             <!-- Normal title -->
                             <template>


### PR DESCRIPTION
fix: 修复UTableView的全选按钮的disable样式